### PR TITLE
fix:子节点过多 会掉下去

### DIFF
--- a/src/lib/vue-okr-tree/OkrTree.vue
+++ b/src/lib/vue-okr-tree/OkrTree.vue
@@ -236,18 +236,31 @@ export default {
   padding: 0;
 }
 .org-chart-container {
-  display: block;
+  display: flex;
   width: 100%;
   text-align: center;
+  overflow: auto;
+  flex-wrap: nowrap;
+  align-content: flex-start;
 }
-
+.org-chart-node-children{
+  overflow: auto;
+  display: flex;
+  flex-wrap: nowrap;
+  align-content: flex-start;
+}
 .vertical .org-chart-node-children {
   position: relative;
   padding-top: 20px;
   transition: all 0.5s;
+  display: flex;
+  flex-wrap: nowrap;
+  align-content: flex-start;
+  overflow: auto;
 }
 .vertical .org-chart-node {
-  float: left;
+  /* float: left; */
+  display: inline-block;
   text-align: center;
   list-style-type: none;
   position: relative;


### PR DESCRIPTION
问题：
子节点过多，宽度小的屏幕，会掉下去
<img width="646" alt="截屏2021-04-27 下午5 47 55" src="https://user-images.githubusercontent.com/34623348/116221967-b50b4800-a780-11eb-9a31-05c4baaffc85.png">

fix后：可横向滚动  前提 包裹 okr-tree的父节点可横向滚动
<img width="1731" alt="截屏2021-04-27 下午5 46 29" src="https://user-images.githubusercontent.com/34623348/116222038-c6545480-a780-11eb-85cb-6cceba4da390.png">
